### PR TITLE
Add support for hiding system information

### DIFF
--- a/lang/ar.xml
+++ b/lang/ar.xml
@@ -23,8 +23,10 @@
     <gray>رمادي</gray>
     <!-- Region -->
     <subset.region>منطقة</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>استورد معلومات النظام</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>معلومات النظام</systemViewInfo>
+    <standard>معيار</standard>
+    <extended>ممتد</extended>
     <yes>نعم</yes>
     <no>لا</no>
     <!-- Subset options for screen / System view -->

--- a/lang/br.xml
+++ b/lang/br.xml
@@ -23,8 +23,10 @@
     <gray>Cinza</gray>
     <!-- Region -->
     <subset.region>Região</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Informações aprimoradas do sistema</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informação do sistema</systemViewInfo>
+    <standard>Padrão</standard>
+    <extended>Estendido</extended>
     <yes>Sim</yes>
     <no>Não</no>
     <!-- Subset options for screen / System view -->

--- a/lang/ca.xml
+++ b/lang/ca.xml
@@ -23,8 +23,10 @@
     <gray>Gris</gray>
     <!-- Region -->
     <subset.region>Regió</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Informació del sistema millorada</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informació del sistema</systemViewInfo>
+    <standard>Estàndard</standard>
+    <extended>Estesa</extended>
     <yes>Sí</yes>
     <no>No</no>
     <!-- Subset options for screen / System view -->

--- a/lang/de.xml
+++ b/lang/de.xml
@@ -23,8 +23,10 @@
     <gray>Grau</gray>
     <!-- Region -->
     <subset.region>Region</subset.region>
-    <!-- Subset-Option für erweiterte Systeminformationen -->
-    <systemViewExInfos>Verbesserte Systeminformationen</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>System information</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Erweitert</extended>
     <yes>Ja</yes>
     <no>Nein</no>
     <!-- Subset-Optionen für Bildschirm -->

--- a/lang/el.xml
+++ b/lang/el.xml
@@ -23,8 +23,10 @@
     <gray>Γκρι</gray>
     <!-- Region -->
     <subset.region>Περιοχή</subset.region>
-    <!-- Επιλογή υποσυνόλου για εκτεταμένες πληροφορίες συστήματος -->
-    <systemViewExInfos>Βελτιωμένες πληροφορίες συστήματος</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Πληροφορίες συστήματος</systemViewInfo>
+    <standard>Πρότυπο</standard>
+    <extended>Επεκτάθηκε</extended>
     <yes>Ναι</yes>
     <no>Όχι</no> 
     <!-- αλλαγή προεπιλογής για μικρές οθόνες -->

--- a/lang/en.xml
+++ b/lang/en.xml
@@ -23,8 +23,10 @@
     <gray>Gray</gray>
     <!-- Region -->
     <subset.region>Region</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Improved system information</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>System information</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Extended</extended>
     <yes>Yes</yes>
     <no>No</no>
     <!-- Subset options for screen / System view -->

--- a/lang/en_GB.xml
+++ b/lang/en_GB.xml
@@ -23,8 +23,10 @@
     <gray>Grey</gray>
     <!-- Region -->
     <subset.region>Region</subset.region>    
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Enhanced system information</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>System information</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Extended</extended>
     <yes>Yes</yes>
     <no>No</no>
     <!-- Subset options for screen / System view -->

--- a/lang/es.xml
+++ b/lang/es.xml
@@ -23,8 +23,10 @@
      <gray>Gris</gray>
     <!-- Region -->
     <subset.region>Región</subset.region>
-     <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Información de sistemas detallada</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Información del sistema</systemViewInfo>
+    <standard>Estándar</standard>
+    <extended>Extendido</extended>
     <yes>Sí</yes>
     <no>No</no>
     <!-- Subset options for screen / System view -->

--- a/lang/fr.xml
+++ b/lang/fr.xml
@@ -23,8 +23,10 @@
     <gray>Gris</gray>
         <!-- Region -->
         <subset.region>Région</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Informations système améliorées</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informations système</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Étendu</extended>
     <yes>Oui</yes>
     <no>Non</no>
     <!-- Subset options for screen / System view -->

--- a/lang/hu.xml
+++ b/lang/hu.xml
@@ -23,8 +23,10 @@
     <gray>Szürke</gray>
     <!-- Régió -->
     <subset.region>Terület</subset.region>
-    <!-- Rendszer bővített információk -->
-    <systemViewExInfos>Bővített rendszerinformáció</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Rendszer információ</systemViewInfo>
+    <standard>Alapértelmezett</standard>
+    <extended>Kiterjedt</extended>
     <yes>Igen</yes>
     <no>Nem</no>
     <!-- Képernyő-beállításai / Rendszer nézet -->

--- a/lang/it.xml
+++ b/lang/it.xml
@@ -23,8 +23,10 @@
      <gray>Grigio</gray>
     <!-- Region -->
     <subset.region>Regione</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Informazioni di sistema migliorate</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informazioni di sistema</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Esteso</extended>
     <yes>Si</yes>
     <no>No</no>
     <!-- Subset options for screen / System view -->

--- a/lang/jp.xml
+++ b/lang/jp.xml
@@ -23,8 +23,10 @@
     <gray>灰色</gray>
     <!-- Region -->
     <subset.region>地域</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>システム情報の充実</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>システムインフォメーション</systemViewInfo>
+    <standard>標準</standard>
+    <extended>拡張された</extended>
     <yes>あり</yes>
     <no>なし</no>
     <!-- Subset options for screen / System view -->

--- a/lang/ko.xml
+++ b/lang/ko.xml
@@ -23,8 +23,10 @@
     <gray>회색</gray>
     <!-- Region -->
     <subset.region>지역</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>향상된 시스템 정보</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>시스템 정보</systemViewInfo>
+    <standard>기준</standard>
+    <extended>펼친</extended>
     <yes>예</yes>
     <no>아니요</no>
     <!-- Subset options for screen / System view -->

--- a/lang/nl.xml
+++ b/lang/nl.xml
@@ -23,8 +23,10 @@
     <gray>Grijs</gray>
     <!-- Region -->
     <subset.region>Regio</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Verbeterde systeeminformatie</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Systeem informatie</systemViewInfo>
+    <standard>Standaard</standard>
+    <extended>Verlengd</extended>
     <yes>Ja</yes>
     <no>Nee</no>
     <!-- Subset options for screen / System view -->

--- a/lang/pl.xml
+++ b/lang/pl.xml
@@ -23,8 +23,10 @@
     <gray>Szary</gray>
     <!-- Region -->
     <subset.region>Region</subset.region>
-    <!-- Opcja rozszerzonych informacji systemowych -->
-    <systemViewExInfos>Rozszerzone informacje o systemie</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informacje o systemie</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Rozszerzony</extended>
     <yes>Tak</yes>
     <no>Nie</no>
     <!-- Opcje ekranu -->

--- a/lang/pt.xml
+++ b/lang/pt.xml
@@ -23,8 +23,10 @@
     <gray>Cinza</gray>
     <!-- Region -->
     <subset.region>Região</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Informações aprimoradas do sistema</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informação do sistema</systemViewInfo>
+    <standard>Padrão</standard>
+    <extended>Estendido</extended>
     <yes>Sim</yes>
     <no>Não</no>
     <!-- Subset options for screen / System view -->

--- a/lang/pt_BR.xml
+++ b/lang/pt_BR.xml
@@ -23,8 +23,10 @@
     <gray>Cinza</gray>
     <!-- Region -->
     <subset.region>Região</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Informações aprimoradas do sistema</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Informação do sistema</systemViewInfo>
+    <standard>Padrão</standard>
+    <extended>Estendido</extended>
     <yes>Sim</yes>
     <no>Não</no>
     <!-- Subset options for screen / System view -->

--- a/lang/ru.xml
+++ b/lang/ru.xml
@@ -23,8 +23,10 @@
     <gray>Серый</gray>
     <!-- Region -->
     <subset.region>Регион</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Расширенная информация о системе</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Системная информация</systemViewInfo>
+    <standard>Стандартный</standard>
+    <extended>Расширенный</extended>
     <yes>Да</yes>
     <no>Нет</no>
     <!-- Subset options for screen / System view -->

--- a/lang/template.xml
+++ b/lang/template.xml
@@ -23,8 +23,10 @@
     <gray>Gray</gray>
     <!-- Region -->
     <subset.region>Region</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Improved system information</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>System information</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Extended</extended>
     <yes>Yes</yes>
     <no>No</no>
     <!-- Subset options for screen / System view -->

--- a/lang/uk.xml
+++ b/lang/uk.xml
@@ -23,8 +23,10 @@
     <gray>Сірий</gray>
     <!-- Region -->
     <subset.region>Регіон</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>Покращена інформація про систему</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>Інформація про систему</systemViewInfo>
+    <standard>Standard</standard>
+    <extended>Extended</extended>
     <yes>Так</yes>
     <no>Немає</no>
     <!-- Subset options for screen / System view -->

--- a/lang/zh.xml
+++ b/lang/zh.xml
@@ -23,8 +23,10 @@
     <gray>灰色</gray>
     <!-- Region -->
     <subset.region>地区</subset.region>
-    <!-- Subset option for System extended informations -->
-    <systemViewExInfos>改善系统信息</systemViewExInfos>
+    <!-- Subset option for System information -->
+    <systemViewInfo>系统信息</systemViewInfo>
+    <standard>标准</standard>
+    <extended>扩展</extended>
     <yes>是</yes>
     <no>否</no>
     <!-- Subset options for screen / System view -->

--- a/subsets/noinfo.xml
+++ b/subsets/noinfo.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<theme>
+  <formatVersion>7</formatVersion>
+  <view name="system">
+    <!-- Hide the system information -->
+    <text name="systemInfo" visible="false"/>
+  </view>
+</theme>

--- a/theme.xml
+++ b/theme.xml
@@ -105,9 +105,9 @@ languages and missing systems (batocera v36): by maioni
   
   <!-- Subset option for System information -->
   <subset name="subsetSystemInfo" displayName="${systemViewInfo}">
-    <include name="none" displayName="${none}">./subsets/noinfo.xml</include>
-    <include name="standard" displayName="${standard}"/>
     <include name="extended" displayName="${extended}" tinyScreen="false">./subsets/extendedinfo.xml</include>
+    <include name="standard" displayName="${standard}"/>
+    <include name="none" displayName="${none}">./subsets/noinfo.xml</include>
   </subset>
   <!-- Subset options for screen -->
   <subset name="systemview" displayName="${systemViewName}">

--- a/theme.xml
+++ b/theme.xml
@@ -36,7 +36,7 @@ languages and missing systems (batocera v36): by maioni
     <orientationSubsetName>Orientation</orientationSubsetName>
     <videosSubsetName>Videos</videosSubsetName>
     <logosSubsetName>Logos</logosSubsetName>
-    <systemViewExInfos>Extended system informations</systemViewExInfos>
+    <systemViewInfo>System information</systemViewInfo>
     <animationsSubsetName>Transition Animations</animationsSubsetName>
     <hideselectionSubsetName>Hide selection</hideselectionSubsetName>
     <systemBackgroundName>System background</systemBackgroundName>
@@ -103,10 +103,11 @@ languages and missing systems (batocera v36): by maioni
   <include>./views/screen.xml</include>
   <include>./views/system.xml</include>
   
-  <!-- Subset option for System extended informations -->
-  <subset name="subsetSystemInfoEx" displayName="${systemViewExInfos}" tinyScreen="false">
-    <include name="yes" displayName="${yes}">./subsets/extendedinfo.xml</include>
-    <include name="no" displayName="${no}"/>
+  <!-- Subset option for System information -->
+  <subset name="subsetSystemInfo" displayName="${systemViewInfo}">
+    <include name="none" displayName="${none}">./subsets/noinfo.xml</include>
+    <include name="standard" displayName="${standard}"/>
+    <include name="extended" displayName="${extended}" tinyScreen="false">./subsets/extendedinfo.xml</include>
   </subset>
   <!-- Subset options for screen -->
   <subset name="systemview" displayName="${systemViewName}">


### PR DESCRIPTION
Extended the `subsetSystemInfoEx` option from a `Yes`/`No` selection to a different `subsetSystemInfo` option with `None`/`Standard`/`Extended` options.
- The `Standard` option behaves the same as `subsetSystemInfoEx=No` did
- The `Extended` option behaves the same `subsetSystemInfoEx=Yes` did
- The `None` option hides the system information entirely with a new subset that makes `systemInfo` invisible