### PR TITLE
Fix Game Genre in Detail View

### DIFF
--- a/subsets/gameinfobar.xml
+++ b/subsets/gameinfobar.xml
@@ -312,11 +312,13 @@
 			<zIndex>100</zIndex>
 		</image>
 	-->
+<!--
     <text name="md_genre">
       <pos>0.55 0.88</pos>
       <size>0.38 0.035</size>
       <alignment>right</alignment>
     </text>
+-->
     <!--
 		<image name="releaseDateImage" extra="true">
 			<visible>false</visible>

--- a/views/detailed.xml
+++ b/views/detailed.xml
@@ -164,6 +164,13 @@ originally based on: "simple" by nils bonenberger
       <alignment>left</alignment>
       <fontSize>0.025</fontSize>
     </text>
+    <text name="md_genre">
+      <color>EFEFFF</color>
+      <pos>0.700 0.875</pos>
+      <size>0.30 0.05</size>
+      <alignment>left</alignment>
+      <fontSize>0.025</fontSize>
+    </text>
     <rating name="md_rating">
       <pos>0.94 0.886</pos>
       <size>0.05 0.03</size>


### PR DESCRIPTION
In detailed view with gameBar is set to False, Game Genre was located at the bottom of game list and mess up last row of gamelist if gamelist is 18 entry or longer. This fix move the Genre to the center-bottom of detail pane regardless of gameBar setting  True/False